### PR TITLE
Fix parameter name in Javadoc

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/deploy/weblogic/exception/DeploymentTaskException.java
+++ b/src/main/java/org/jenkinsci/plugins/deploy/weblogic/exception/DeploymentTaskException.java
@@ -52,7 +52,7 @@ public class DeploymentTaskException extends RuntimeException {
 	
 	/**
 	 * 
-	 * @param message
+	 * @param result
 	 */
 	public DeploymentTaskException(DeploymentTaskResult result) {
 		super();


### PR DESCRIPTION
Maven build fails if skipTests is false.

Signed-off-by: Mustafa Ulu <mustafau@sabanciuniv.edu>