### PR TITLE
[JENKINS#37464] Extend deployment policy configuration

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin.java
@@ -5,6 +5,7 @@ package org.jenkinsci.plugins.deploy.weblogic;
 
 import hudson.Extension;
 import hudson.Launcher;
+import hudson.Util;
 import hudson.init.Initializer;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -12,15 +13,18 @@ import hudson.model.Action;
 import hudson.model.AutoCompletionCandidates;
 import hudson.model.BuildListener;
 import hudson.model.Cause;
+import hudson.model.Descriptor;
 import hudson.model.Hudson;
 import hudson.model.JDK;
 import hudson.model.Job;
 import hudson.model.Result;
+import hudson.model.Saveable;
 import hudson.model.TopLevelItem;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
+import hudson.util.DescribableList;
 import hudson.util.FormValidation;
 
 import java.io.File;
@@ -51,6 +55,7 @@ import org.jenkinsci.plugins.deploy.weblogic.data.WebLogicDeploymentStatus;
 import org.jenkinsci.plugins.deploy.weblogic.data.WebLogicPreRequisteStatus;
 import org.jenkinsci.plugins.deploy.weblogic.data.WebLogicStageMode;
 import org.jenkinsci.plugins.deploy.weblogic.data.WeblogicEnvironment;
+import org.jenkinsci.plugins.deploy.weblogic.data.policy.AbstractDeploymentPolicy;
 import org.jenkinsci.plugins.deploy.weblogic.exception.DeploymentTaskException;
 import org.jenkinsci.plugins.deploy.weblogic.exception.LoadingFileException;
 import org.jenkinsci.plugins.deploy.weblogic.jdk.JdkToolService;
@@ -75,9 +80,7 @@ import com.google.inject.Inject;
  */
 @Extension
 public class WeblogicDeploymentPlugin extends Recorder {
-	
-	public static transient final String NON_DEPLOYMENT_STRATEGY_VALUE_SPECIFIED = "unknown";
-	
+
 	public static transient final String DEFAULT_JAVA_OPTIONS_DEPLOYER = "-Xms256M -Xmx256M";
 	
 	@Inject
@@ -96,8 +99,8 @@ public class WeblogicDeploymentPlugin extends Recorder {
 	/**
 	 * strategies de deploiement (rattache a un trigger de build)
 	 */
-	private List<String> selectedDeploymentStrategyIds;
-	
+	private transient List<String> selectedDeploymentStrategyIds;
+
 	/**
 	 * le deploiement est effectif uniquement si les sources ont changes
 	 */
@@ -114,7 +117,14 @@ public class WeblogicDeploymentPlugin extends Recorder {
 	 * Deployment task list
 	 */
 	private List<DeploymentTask> tasks = new ArrayList<DeploymentTask>();
-	
+
+	/**
+	 * Deployment policy list
+	 *
+	 * @since 3.5
+	 */
+	private DescribableList<AbstractDeploymentPolicy, Descriptor<AbstractDeploymentPolicy>> policies;
+
 	public WeblogicDeploymentPlugin() {
 		super();
 	}
@@ -132,6 +142,15 @@ public class WeblogicDeploymentPlugin extends Recorder {
 	 * @param deployedProjectsDependencies
 	 * @param isDeployingOnlyWhenUpdates
 	 * @param forceStopOnFirstFailure
+	 * @param buildUnstableWhenDeploymentUnstable
+	 * @param weblogicEnvironmentTargetedName
+	 * @param deploymentName
+	 * @param deploymentTargets
+	 * @param isLibrary
+	 * @param builtResourceRegexToDeploy
+	 * @param baseResourcesGeneratedDirectory
+	 * @param deploymentPlan
+	 * @param policies
 	 * @since 2.0
 	 */
 	@DataBoundConstructor
@@ -139,20 +158,58 @@ public class WeblogicDeploymentPlugin extends Recorder {
     		String deployedProjectsDependencies, boolean isDeployingOnlyWhenUpdates, boolean forceStopOnFirstFailure,
     		boolean buildUnstableWhenDeploymentUnstable, String weblogicEnvironmentTargetedName, String deploymentName, 
     		String deploymentTargets, boolean isLibrary, String builtResourceRegexToDeploy, String baseResourcesGeneratedDirectory, 
-    		String deploymentPlan) {
+    		String deploymentPlan, List<AbstractDeploymentPolicy> policies) {
         // ATTENTION : Appele au moment de la sauvegarde : On conserve la compatibilite ascendante
 		this.tasks = CollectionUtils.isNotEmpty(tasks) ? tasks : Arrays.asList(new DeploymentTask[]{
 				new DeploymentTask(null, null, weblogicEnvironmentTargetedName, deploymentName, deploymentTargets, isLibrary,
 						builtResourceRegexToDeploy, baseResourcesGeneratedDirectory , null, null, null, null, deploymentPlan)
 				});
 		this.mustExitOnFailure = mustExitOnFailure;
-        this.selectedDeploymentStrategyIds = selectedDeploymentStrategyIds;
+		this.selectedDeploymentStrategyIds = selectedDeploymentStrategyIds;
         this.deployedProjectsDependencies = deployedProjectsDependencies;
         this.isDeployingOnlyWhenUpdates = isDeployingOnlyWhenUpdates;
         this.forceStopOnFirstFailure = forceStopOnFirstFailure;
         this.buildUnstableWhenDeploymentUnstable = buildUnstableWhenDeploymentUnstable;
+		this.policies = new DescribableList<AbstractDeploymentPolicy, Descriptor<AbstractDeploymentPolicy>>(Saveable.NOOP, Util.fixNull(policies));
 		// TODO Si on veut faire du controle
     }
+
+	protected Object readResolve() {
+		if (CollectionUtils.isNotEmpty(selectedDeploymentStrategyIds)) {
+			this.policies = new DescribableList<AbstractDeploymentPolicy, Descriptor<AbstractDeploymentPolicy>>(Saveable.NOOP, Util.fixNull(toDeploymentPolicyList(clearDeploymentStrategyIds(selectedDeploymentStrategyIds), isDeployingOnlyWhenUpdates)));
+		}
+		return this;
+	}
+
+	private List<AbstractDeploymentPolicy> toDeploymentPolicyList(List<String> deploymentStrategyIds, boolean deployingOnlyWhenUpdates) {
+		List<AbstractDeploymentPolicy> policies = new ArrayList<AbstractDeploymentPolicy>();
+		List<Descriptor<AbstractDeploymentPolicy>> descriptors = Jenkins.getInstance().getDescriptorList(AbstractDeploymentPolicy.class);
+		for (Descriptor<AbstractDeploymentPolicy> descriptor : descriptors) {
+			try {
+				AbstractDeploymentPolicy policy = descriptor.clazz.getConstructor(Boolean.TYPE).newInstance(deployingOnlyWhenUpdates);
+				for (String deploymentStrategyId : deploymentStrategyIds) {
+					if (policy.getCauseClass().getName().equals(deploymentStrategyId)) {
+						policies.add(policy);
+					}
+				}
+			} catch(Exception e) {
+				e.printStackTrace();
+			}
+		}
+		return policies;
+	}
+
+	/**
+	 * On ne controle la desactivation que si la strategie a ete definie
+	 * gestion des classes privees : les tokens \$ sont transformees en $
+	 */
+	private List<String> clearDeploymentStrategyIds(List<String> deploymentStrategyIds) {
+		List<String> cleared = new ArrayList<String>();
+		for (String deploymentStrategyId : deploymentStrategyIds){
+			cleared.add(StringUtils.remove(deploymentStrategyId, '\\'));
+		}
+		return cleared;
+	}
 
 	/**
 	 * 
@@ -196,7 +253,14 @@ public class WeblogicDeploymentPlugin extends Recorder {
 	public List<DeploymentTask> getTasks() {
 		return tasks;
 	}
-	
+
+	/**
+	 * @return the policies
+	 */
+	public List<AbstractDeploymentPolicy> getPolicies() {
+		return policies;
+	}
+
 	/**
 	 * @return the forceStopOnFirstFailure
 	 */
@@ -219,10 +283,10 @@ public class WeblogicDeploymentPlugin extends Recorder {
 	 */
 	@Override
 	public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        
+
         //Pre-requis ko , arret du traitement
         List<DeploymentTaskResult> results = new ArrayList<DeploymentTaskResult>();
-        WebLogicPreRequisteStatus check = checkPreRequisites( build, launcher, listener);
+        WebLogicPreRequisteStatus check = checkPreRequisites(build, listener);
         if(check != WebLogicPreRequisteStatus.OK){
         	results.add(new DeploymentTaskResult(check, WebLogicDeploymentStatus.DISABLED, null, null));
         	return exitPerformAction(build, listener, results);
@@ -251,33 +315,25 @@ public class WeblogicDeploymentPlugin extends Recorder {
 	/**
 	 * 
 	 * @param build
-	 * @param launcher
 	 * @param listener
 	 * @return
 	 */
-	private WebLogicPreRequisteStatus checkPreRequisites(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener){
+	private WebLogicPreRequisteStatus checkPreRequisites(AbstractBuild<?, ?> build, BuildListener listener){
 		
 		//Verification desactivation plugin
 		if(getDescriptor().isPluginDisabled()){
 			listener.getLogger().println("[WeblogicDeploymentPlugin] - The plugin execution is disabled.");
 			return WebLogicPreRequisteStatus.PLUGIN_DISABLED;
 		}
-				
-		//Verification coherence du (des) declencheur(s)
-		boolean isSpecifiedDeploymentStrategyValue = true;
-		if(CollectionUtils.isEmpty(selectedDeploymentStrategyIds) || 
-				(selectedDeploymentStrategyIds.size() == 1 && selectedDeploymentStrategyIds.contains(NON_DEPLOYMENT_STRATEGY_VALUE_SPECIFIED))){
-			isSpecifiedDeploymentStrategyValue = false;
-		}
-		
-		if(isSpecifiedDeploymentStrategyValue && !hasAtLeastOneBuildCauseChecked(build, selectedDeploymentStrategyIds)){
-			listener.getLogger().println("[WeblogicDeploymentPlugin] - Current build causes do not contain any of the configured (configured=" +StringUtils.join(selectedDeploymentStrategyIds,';')+ ") (currents=" +StringUtils.join(build.getCauses(),';')+ ") : The plugin execution is disabled.");
+
+		if (!policies.isEmpty() && !hasAtLeastOneBuildCauseChecked(build)) {
+			listener.getLogger().println("[WeblogicDeploymentPlugin] - Current build causes (" + StringUtils.join(build.getCauses(), ", ") + ") do not contain any of the configured (" + StringUtils.join(policies, ", ") + "). The plugin execution is disabled.");
 			return WebLogicPreRequisteStatus.OTHER_TRIGGER_CAUSE;
 		}
 		
 		//Verification strategie relative a la gestion des sources (systematique (par defaut) / uniquement sur modification(actif) )
 		if(isDeployingOnlyWhenUpdates && build.getChangeSet().isEmptySet()) {
-			listener.getLogger().println("[WeblogicDeploymentPlugin] - No changes : The plugin execution is disabled.");
+			listener.getLogger().println("[WeblogicDeploymentPlugin] - No changes. The plugin execution is disabled.");
 			return WebLogicPreRequisteStatus.NO_CHANGES;
 		}
 		
@@ -290,7 +346,7 @@ public class WeblogicDeploymentPlugin extends Recorder {
 				TopLevelItem item = Hudson.getInstance().getItem(listeDependances[i]);
 				if(item instanceof Job){
 					WatchingWeblogicDeploymentAction deploymentAction = ((Job<?,?>) item).getLastBuild().getAction(WatchingWeblogicDeploymentAction.class);
-					listener.getLogger().println("[WeblogicDeploymentPlugin] - satisfying dependencies project involved : " + item.getName());
+					listener.getLogger().println("[WeblogicDeploymentPlugin] - Satisfying dependencies project involved: " + item.getName());
 					if(deploymentAction != null && CollectionUtils.exists(deploymentAction.getResults(), new TaskStatusUnSuccesfullPredicate())){
 						satisfiedDependenciesDeployments = false;
 					}
@@ -298,7 +354,7 @@ public class WeblogicDeploymentPlugin extends Recorder {
 			}
 			
 			if(!satisfiedDependenciesDeployments){
-				listener.getLogger().println("[WeblogicDeploymentPlugin] - Not satisfied project dependencies deployment : The plugin execution is disabled.");
+				listener.getLogger().println("[WeblogicDeploymentPlugin] - Not satisfied project dependencies deployment. The plugin execution is disabled.");
 				return WebLogicPreRequisteStatus.UNSATISFIED_DEPENDENCIES;
 			}
 		}
@@ -311,7 +367,27 @@ public class WeblogicDeploymentPlugin extends Recorder {
 
 		return WebLogicPreRequisteStatus.OK;		
 	}
-	
+
+	/**
+	 *
+	 * @param build
+	 * @return
+	 */
+	private boolean hasAtLeastOneBuildCauseChecked(AbstractBuild<?, ?> build) {
+		for (Cause cause : build.getCauses()) {
+			for (AbstractDeploymentPolicy policy : policies) {
+				if (policy.getCauseClass().getName().equals(cause.getClass().getName())) {
+					if (!policy.isDeployingOnlyWhenUpdates()) {
+						return true;
+					} else if (!build.getChangeSet().isEmptySet()) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
 	/*
 	 * 	(non-Javadoc)
 	 * @see hudson.model.AbstractDescribableImpl#getDescriptor()
@@ -706,33 +782,12 @@ public class WeblogicDeploymentPlugin extends Recorder {
 		public boolean isApplicable(Class<? extends AbstractProject> jobType) {
 				return true;
 		}
-	}
-	
-	
-	/**
-	 * 
-	 * @param build
-	 * @param deploymentStrategies
-	 * @return
-	 */
-	private boolean hasAtLeastOneBuildCauseChecked(AbstractBuild<?, ?> build, List<String> deploymentStrategies) {
-		boolean isProperlyBuildCause = false;
-		//On ne controle la desactivation que si la strategie a ete definie
-		//gestion des classes privees : les tokens \$ sont transformees en $
-		List<String> searchedCauseIds = new ArrayList<String>();
-		for(String elt : deploymentStrategies){
-			searchedCauseIds.add(StringUtils.remove(elt, '\\'));
+
+		public List<? extends Descriptor<AbstractDeploymentPolicy>> getDeploymentPolicyDescriptors() {
+			return Jenkins.getInstance().getDescriptorList(AbstractDeploymentPolicy.class);
 		}
-		
-		List<Cause> causes = build.getCauses();
-		for(Cause cause : causes){
-			if(searchedCauseIds.contains(cause.getClass().getName())) {
-				isProperlyBuildCause = true;
-			}
-		}
-		return isProperlyBuildCause;
 	}
-	
+
 	/**
 	 * 
 	 * @param build

--- a/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/AbstractDeploymentPolicy.java
+++ b/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/AbstractDeploymentPolicy.java
@@ -1,0 +1,32 @@
+package org.jenkinsci.plugins.deploy.weblogic.data.policy;
+
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Cause;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.Serializable;
+
+/**
+ * @author Mustafa Ulu
+ *
+ * @since 3.5
+ */
+public abstract class AbstractDeploymentPolicy extends AbstractDescribableImpl<AbstractDeploymentPolicy> implements Serializable {
+
+    private boolean deployingOnlyWhenUpdates;
+
+    @DataBoundConstructor
+    public AbstractDeploymentPolicy(boolean deployingOnlyWhenUpdates) {
+        this.deployingOnlyWhenUpdates = deployingOnlyWhenUpdates;
+    }
+
+    public AbstractDeploymentPolicy(AbstractDeploymentPolicy deploymentPolicy) {
+        this.deployingOnlyWhenUpdates = deploymentPolicy.isDeployingOnlyWhenUpdates();
+    }
+
+    public abstract Class<? extends Cause> getCauseClass();
+
+    public boolean isDeployingOnlyWhenUpdates() {
+        return deployingOnlyWhenUpdates;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/DeploymentTriggerCauseDeploymentPolicy.java
+++ b/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/DeploymentTriggerCauseDeploymentPolicy.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.deploy.weblogic.data.policy;
+
+import hudson.Extension;
+import hudson.model.Cause;
+import hudson.model.Descriptor;
+import org.jenkinsci.plugins.deploy.weblogic.Messages;
+import org.jenkinsci.plugins.deploy.weblogic.trigger.DeploymentTrigger;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * @author Mustafa Ulu
+ *
+ * @since 3.5
+ */
+public class DeploymentTriggerCauseDeploymentPolicy extends AbstractDeploymentPolicy {
+
+    private static Class<? extends Cause> causeClass = DeploymentTrigger.DeploymentTriggerCause.class;
+
+    @Extension
+    public static class DeploymentPolicyDescriptor extends Descriptor<AbstractDeploymentPolicy> {
+
+        public DeploymentPolicyDescriptor() {
+            super(DeploymentTriggerCauseDeploymentPolicy.class);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.DeploymentTrigger_DeploymentTriggerCause_ShortDescription();
+        }
+    }
+
+    @DataBoundConstructor
+    public DeploymentTriggerCauseDeploymentPolicy(boolean deployingOnlyWhenUpdates) {
+        super(deployingOnlyWhenUpdates);
+    }
+
+    public DeploymentTriggerCauseDeploymentPolicy(DeploymentTriggerCauseDeploymentPolicy deploymentPolicy) {
+        super(deploymentPolicy);
+    }
+
+    public Class<? extends Cause> getCauseClass() {
+        return causeClass;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/RemoteCauseDeploymentPolicy.java
+++ b/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/RemoteCauseDeploymentPolicy.java
@@ -1,0 +1,43 @@
+package org.jenkinsci.plugins.deploy.weblogic.data.policy;
+
+import hudson.Extension;
+import hudson.model.Cause;
+import hudson.model.Descriptor;
+import org.jenkinsci.plugins.deploy.weblogic.Messages;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * @author Mustafa Ulu
+ *
+ * @since 3.5
+ */
+public class RemoteCauseDeploymentPolicy extends AbstractDeploymentPolicy {
+
+    private static Class<? extends Cause> causeClass = Cause.RemoteCause.class;
+
+    @Extension
+    public static class DeploymentPolicyDescriptor extends Descriptor<AbstractDeploymentPolicy> {
+
+        public DeploymentPolicyDescriptor() {
+            super(RemoteCauseDeploymentPolicy.class);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Cause_RemoteCause_DisplayName();
+        }
+    }
+
+    @DataBoundConstructor
+    public RemoteCauseDeploymentPolicy(boolean deployingOnlyWhenUpdates) {
+        super(deployingOnlyWhenUpdates);
+    }
+
+    public RemoteCauseDeploymentPolicy(RemoteCauseDeploymentPolicy deploymentPolicy) {
+        super(deploymentPolicy);
+    }
+
+    public Class<? extends Cause> getCauseClass() {
+        return causeClass;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/SCMTriggerCauseDeploymentPolicy.java
+++ b/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/SCMTriggerCauseDeploymentPolicy.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.deploy.weblogic.data.policy;
+
+import hudson.Extension;
+import hudson.model.Cause;
+import hudson.model.Descriptor;
+import hudson.triggers.Messages;
+import hudson.triggers.SCMTrigger;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * @author Mustafa Ulu
+ *
+ * @since 3.5
+ */
+public class SCMTriggerCauseDeploymentPolicy extends AbstractDeploymentPolicy {
+
+    private static Class<? extends Cause> causeClass = SCMTrigger.SCMTriggerCause.class;
+
+    @Extension
+    public static class DeploymentPolicyDescriptor extends Descriptor<AbstractDeploymentPolicy> {
+
+        public DeploymentPolicyDescriptor() {
+            super(SCMTriggerCauseDeploymentPolicy.class);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.SCMTrigger_SCMTriggerCause_ShortDescription();
+        }
+    }
+
+    @DataBoundConstructor
+    public SCMTriggerCauseDeploymentPolicy(boolean deployingOnlyWhenUpdates) {
+        super(deployingOnlyWhenUpdates);
+    }
+
+    public SCMTriggerCauseDeploymentPolicy(SCMTriggerCauseDeploymentPolicy deploymentPolicy) {
+        super(deploymentPolicy);
+    }
+
+    public Class<? extends Cause> getCauseClass() {
+        return causeClass;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/TimerTriggerCauseDeploymentPolicy.java
+++ b/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/TimerTriggerCauseDeploymentPolicy.java
@@ -1,0 +1,45 @@
+package org.jenkinsci.plugins.deploy.weblogic.data.policy;
+
+import hudson.Extension;
+import hudson.model.Cause;
+import hudson.model.Descriptor;
+import hudson.triggers.Messages;
+import hudson.triggers.TimerTrigger;
+import org.jenkinsci.plugins.deploy.weblogic.trigger.DeploymentTrigger;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * @author Mustafa Ulu
+ *
+ * @since 3.5
+ */
+public class TimerTriggerCauseDeploymentPolicy extends AbstractDeploymentPolicy {
+
+    private static Class<? extends Cause> causeClass = TimerTrigger.TimerTriggerCause.class;
+
+    @Extension
+    public static class DeploymentPolicyDescriptor extends Descriptor<AbstractDeploymentPolicy> {
+
+        public DeploymentPolicyDescriptor() {
+            super(TimerTriggerCauseDeploymentPolicy.class);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.TimerTrigger_TimerTriggerCause_ShortDescription();
+        }
+    }
+
+    @DataBoundConstructor
+    public TimerTriggerCauseDeploymentPolicy(boolean deployingOnlyWhenUpdates) {
+        super(deployingOnlyWhenUpdates);
+    }
+
+    public TimerTriggerCauseDeploymentPolicy(TimerTriggerCauseDeploymentPolicy deploymentPolicy) {
+        super(deploymentPolicy);
+    }
+
+    public Class<? extends Cause> getCauseClass() {
+        return causeClass;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/UpstreamCauseDeploymentPolicy.java
+++ b/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/UpstreamCauseDeploymentPolicy.java
@@ -1,0 +1,43 @@
+package org.jenkinsci.plugins.deploy.weblogic.data.policy;
+
+import hudson.Extension;
+import hudson.model.Cause;
+import hudson.model.Descriptor;
+import org.jenkinsci.plugins.deploy.weblogic.Messages;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * @author Mustafa Ulu
+ *
+ * @since 3.5
+ */
+public class UpstreamCauseDeploymentPolicy extends AbstractDeploymentPolicy {
+
+    private static Class<? extends Cause> causeClass = Cause.UpstreamCause.class;
+
+    @Extension
+    public static class DeploymentPolicyDescriptor extends Descriptor<AbstractDeploymentPolicy> {
+
+        public DeploymentPolicyDescriptor() {
+            super(UpstreamCauseDeploymentPolicy.class);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Cause_UpstreamCause_DisplayName();
+        }
+    }
+
+    @DataBoundConstructor
+    public UpstreamCauseDeploymentPolicy(boolean deployingOnlyWhenUpdates) {
+        super(deployingOnlyWhenUpdates);
+    }
+
+    public UpstreamCauseDeploymentPolicy(UpstreamCauseDeploymentPolicy deploymentPolicy) {
+        super(deploymentPolicy);
+    }
+
+    public Class<? extends Cause> getCauseClass() {
+        return causeClass;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/UserIdCauseDeploymentPolicy.java
+++ b/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/UserIdCauseDeploymentPolicy.java
@@ -1,0 +1,43 @@
+package org.jenkinsci.plugins.deploy.weblogic.data.policy;
+
+import hudson.Extension;
+import hudson.model.Cause;
+import hudson.model.Descriptor;
+import org.jenkinsci.plugins.deploy.weblogic.Messages;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * @author Mustafa Ulu
+ *
+ * @since 3.5
+ */
+public class UserIdCauseDeploymentPolicy extends AbstractDeploymentPolicy {
+
+    private static Class<? extends Cause> causeClass = Cause.UserIdCause.class;
+
+    @Extension
+    public static class DeploymentPolicyDescriptor extends Descriptor<AbstractDeploymentPolicy> {
+
+        public DeploymentPolicyDescriptor() {
+            super(UserIdCauseDeploymentPolicy.class);
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.Cause_UserIdCause_DisplayName();
+        }
+    }
+
+    @DataBoundConstructor
+    public UserIdCauseDeploymentPolicy(boolean deployingOnlyWhenUpdates) {
+        super(deployingOnlyWhenUpdates);
+    }
+
+    public UserIdCauseDeploymentPolicy(UserIdCauseDeploymentPolicy deploymentPolicy) {
+        super(deploymentPolicy);
+    }
+
+    public Class<? extends Cause> getCauseClass() {
+        return causeClass;
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/Messages.properties
@@ -1,6 +1,9 @@
 WatchingWeblogicDeploymentAction.DisplayName=WebLogic Deployments
 WeblogicDeploymentPluginDescriptor.DisplayName=Deploy the artifact to any WebLogic environments
 DeploymentTrigger.DisplayName=Deploy periodically
-DeploymentTrigger.Cause.ShortDescription=Started by timer
 DeploymentTrigger.DeploymentTriggerCause.ShortDescription=Started by deployment timer
 DeploymentTaskDescriptor.DisplayName=Configure a deployment task
+
+Cause.UpstreamCause.DisplayName=Built after other projects are built or whenever a SNAPSHOT dependency is built
+Cause.UserIdCause.DisplayName=Started by user
+Cause.RemoteCause.DisplayName=Started by remote host

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/Messages_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/Messages_fr.properties
@@ -1,6 +1,9 @@
 WatchingWeblogicDeploymentAction.DisplayName=Deploiements WebLogic
 WeblogicDeploymentPluginDescriptor.DisplayName=D\u00E9ployer l''artifact sur des cibles WebLogic
 DeploymentTrigger.DisplayName=D\u00E9ployer l''artifact p\u00E9riodiquement
-DeploymentTrigger.Cause.ShortDescription=L''\u00E9ch\u00E9ance d''une alarme p\u00E9riodique a provoqu\u00E9 le lancement de ce job
 DeploymentTrigger.DeploymentTriggerCause.ShortDescription=L''\u00E9ch\u00E9ance d''un deploiement p\u00E9riodique a provoqu\u00E9 le lancement de ce job
 DeploymentTaskDescriptor.DisplayName=Configurer une tache de d\u00E9ploiement
+
+Cause.UpstreamCause.DisplayName=D\u00e9marr\u00e9 par d''autres projets (projets en amont ou d\u00e9pendance SNAPSHOT construite)
+Cause.UserIdCause.DisplayName=D\u00e9marr\u00e9 par un utilisateur
+Cause.RemoteCause.DisplayName=D\u00e9marr\u00e9 \u00e0 distance

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/config.jelly
@@ -43,23 +43,15 @@
 			<f:entry title="${%ForceStopOnFirstFailure}" field="forceStopOnFirstFailure">
 		  		<f:checkbox name="forceStopOnFirstFailure" checked="${instance.forceStopOnFirstFailure}" />
 		  	</f:entry>
-			
-		  	<f:entry title="${%DeploymentStrategy}" field="selectedDeploymentStrategyIds">
-		  		<select class="setting-input" multiple="multiple" size="3" name="selectedDeploymentStrategyIds">    		
-					<!-- valeur par defaut -->
-					<f:option value="unknown">${%NoSpecified}</f:option>
-					<!-- liste des causes referencees-->
-					<f:option value="hudson.model.Cause\\$LegacyCodeCause" selected="${instance.selectedDeploymentStrategyIds.contains('hudson.model.Cause\\$LegacyCodeCause')}">${%Cause.LegacyCodeCause}</f:option>
-					<f:option value="hudson.model.Cause\\$UserCause" selected="${instance.selectedDeploymentStrategyIds.contains('hudson.model.Cause\\$UserCause')}">${%Cause.UserCause}</f:option>
-					<f:option value="hudson.model.Cause\\$UserIdCause" selected="${instance.selectedDeploymentStrategyIds.contains('hudson.model.Cause\\$UserIdCause')}">${%Cause.UserIdCause}</f:option>
-					<f:option value="hudson.model.Cause\\$RemoteCause" selected="${instance.selectedDeploymentStrategyIds.contains('hudson.model.Cause\\$RemoteCause')}">${%Cause.RemoteCause}</f:option>
-		    		<f:option value="hudson.model.Cause\\$UpstreamCause" selected="${instance.selectedDeploymentStrategyIds.contains('hudson.model.Cause\\$UpstreamCause')}">${%Cause.UpstreamCause}</f:option>
-		    		<f:option value="org.jenkinsci.plugins.deploy.weblogic.trigger.DeploymentTrigger\\$DeploymentTriggerCause" selected="${instance.selectedDeploymentStrategyIds.contains('org.jenkinsci.plugins.deploy.weblogic.trigger.DeploymentTrigger\\$DeploymentTriggerCause')}">${%Cause.DeploymentTriggerCause}</f:option>
-		    		<f:option value="hudson.triggers.SCMTrigger\\$SCMTriggerCause" selected="${instance.selectedDeploymentStrategyIds.contains('hudson.triggers.SCMTrigger\\$SCMTriggerCause')}">${%Cause.SCMTriggerCause}</f:option>
-					<f:option value="hudson.triggers.TimerTrigger\\$TimerTriggerCause" selected="${instance.selectedDeploymentStrategyIds.contains('hudson.triggers.TimerTrigger\\$TimerTriggerCause')}">${%Cause.TimerTriggerCause}</f:option>
-				</select>
-			</f:entry>
-			
+
+			<!-- Deployment policies -->
+			<f:nested>
+				<f:entry title="${%policy.title}">
+                    <f:hetero-list name="policies" hasHeader="true" oneEach="true" addCaption="${%policy.label.add}"
+                        descriptors="${descriptor.getDeploymentPolicyDescriptors()}" items="${instance.policies}" />
+				</f:entry>
+			</f:nested>
+
 			<f:entry title="${%SourceManagementDeploymentCriteria}" field="isDeployingOnlyWhenUpdates">
 		  		<f:checkbox name="isDeployingOnlyWhenUpdates" checked="${instance.isDeployingOnlyWhenUpdatese}" />
 		  	</f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/config.properties
@@ -1,15 +1,6 @@
 MustExitOnFailure=Fail build if deployment fails
 ForceStopOnFirstFailure=Stop deployment tasks on first failure
 DeploymentStrategy=Deployment policy
-NoSpecified=Non specified
-Cause.UpstreamCause=Built after other projects are built or whenever a SNAPSHOT dependency is built
-Cause.LegacyCodeCause=Legacy code started this job. No cause information is available
-Cause.UserCause=Started by user (deprecated)
-Cause.UserIdCause=Started by user
-Cause.RemoteCause=Started by remote host
-Cause.DeploymentTriggerCause=Started by deployment timer
-Cause.SCMTriggerCause=Started by an SCM change
-Cause.TimerTriggerCause=Started by build timer
 DeployedProjectsDependencies=Projects deployment dependencies
 DeployedProjectsDependenciesDescription=Multiple projects can be specified like 'abc, def'. If blank, control is disabled.
 SourceManagementDeploymentCriteria=Deploy only when sources change
@@ -19,3 +10,6 @@ PluginConfigurationMissing.error.2=Please do so from <a href="{0}/configure" tar
 title=Deployment tasks
 label.add=Add a deployment task
 label.delete=Delete the deployment task
+policy.title=Deployment policies
+policy.label.add=Add deployment policy
+policy.label.delete=Delete deployment policy

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/config_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/config_fr.properties
@@ -1,14 +1,6 @@
 MustExitOnFailure=Build en echec si erreur au deploiement
 ForceStopOnFirstFailure=Stopper les deploiements au 1er \u00e9chec
 DeploymentStrategy=Strategie de deploiement
-NoSpecified=Non specifie
-Cause.LegacyCodeCause=Ce job a \u00e9t\u00e9 lanc\u00e9 par du code legacy. Pas d''information sur les causes
-Cause.UpstreamCause=D\u00e9marr\u00e9 par d''autres projets (projets en amont ou d\u00e9pendance SNAPSHOT construite)
-Cause.UserCause=D\u00e9marr\u00e9 par un utilisateur (obsolete)
-Cause.UserIdCause=D\u00e9marr\u00e9 par un utilisateur
-Cause.RemoteCause=D\u00e9marr\u00e9 \u00e0 distance
-Cause.DeploymentTriggerCause=Deploiement p\u00E9riodique
-Cause.SCMTriggerCause=Changement dans la base de code
 DeployedProjectsDependencies=Projets d\u00e9ploy\u00e9s requis
 DeployedProjectsDependenciesDescription=Plusieurs projets peuvent etre sp\u00e9cifi\u00e9s ainsi : 'abc, def'. Si vide, le contr\u00f4le est d\u00e9sactiv\u00e9.
 SourceManagementDeploymentCriteria=Deploiement uniquement sur modifications des sources

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/help-deploymentStrategyId.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/help-deploymentStrategyId.html
@@ -1,1 +1,0 @@
-<div>the trigger which triggers the job build and triggers the deployment task. If the job build is triggered by another one, the deployment task will be disabled.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/help-deploymentStrategyId_fr.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/help-deploymentStrategyId_fr.html
@@ -1,1 +1,0 @@
-<div>declencheur de build sur lequel le deploiement sera declench&eacute;. Dans le cas contraire, le d&eacute;ploiement sera d&eacute;sactiv&eacute;.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/help-isDeployingOnlyWhenUpdates.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/help-isDeployingOnlyWhenUpdates.html
@@ -3,4 +3,5 @@
 <li>on each build. Whatever the sources changes the deployment task is executed (default mode).</li>
 <li>on sources modification. The deployment task is executed if the project sources has been modified.</li>
 </ul>
+<p>Note that setting this option overrides individual policies selected above.</p>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/help-selectedDeploymentStrategyIds.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/help-selectedDeploymentStrategyIds.html
@@ -1,1 +1,0 @@
-<div>The deployment policy.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/help-selectedDeploymentStrategyIds_fr.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/help-selectedDeploymentStrategyIds_fr.html
@@ -1,1 +1,0 @@
-<div>La strat&eacute;gie de d&eacute;ploiement d&eacute;clenchant le d&eacute;marrage du d&eacute;ploiement.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/DeploymentTriggerCauseDeploymentPolicy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/DeploymentTriggerCauseDeploymentPolicy/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project" xmlns:util="jelly:util">
+
+	<f:entry title="" field="deployingOnlyWhenUpdates">
+		<f:checkbox name="deployingOnlyWhenUpdates" checked="${instance.deployingOnlyWhenUpdates}" title="${%SourceManagementDeploymentCriteria}" />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/DeploymentTriggerCauseDeploymentPolicy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/DeploymentTriggerCauseDeploymentPolicy/config.properties
@@ -1,0 +1,1 @@
+SourceManagementDeploymentCriteria=Deploy only when sources change

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/DeploymentTriggerCauseDeploymentPolicy/config_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/DeploymentTriggerCauseDeploymentPolicy/config_fr.properties
@@ -1,0 +1,1 @@
+SourceManagementDeploymentCriteria=Deploiement uniquement sur modifications des sources

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/DeploymentTriggerCauseDeploymentPolicy/help-deployingOnlyWhenUpdates.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/DeploymentTriggerCauseDeploymentPolicy/help-deployingOnlyWhenUpdates.html
@@ -1,0 +1,1 @@
+<div>The deployment task is executed if the project sources has been modified.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/DeploymentTriggerCauseDeploymentPolicy/help-deployingOnlyWhenUpdates_fr.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/DeploymentTriggerCauseDeploymentPolicy/help-deployingOnlyWhenUpdates_fr.html
@@ -1,0 +1,1 @@
+<div>Le deploiement n'est r&eacute;alis&eacute; que si les sources ont boug&eacute;.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/RemoteCauseDeploymentPolicy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/RemoteCauseDeploymentPolicy/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project" xmlns:util="jelly:util">
+
+	<f:entry title="" field="deployingOnlyWhenUpdates">
+		<f:checkbox name="deployingOnlyWhenUpdates" checked="${instance.deployingOnlyWhenUpdates}" title="${%SourceManagementDeploymentCriteria}" />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/RemoteCauseDeploymentPolicy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/RemoteCauseDeploymentPolicy/config.properties
@@ -1,0 +1,1 @@
+SourceManagementDeploymentCriteria=Deploy only when sources change

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/RemoteCauseDeploymentPolicy/config_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/RemoteCauseDeploymentPolicy/config_fr.properties
@@ -1,0 +1,1 @@
+SourceManagementDeploymentCriteria=Deploiement uniquement sur modifications des sources

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/RemoteCauseDeploymentPolicy/help-deployingOnlyWhenUpdates.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/RemoteCauseDeploymentPolicy/help-deployingOnlyWhenUpdates.html
@@ -1,0 +1,1 @@
+<div>The deployment task is executed if the project sources has been modified.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/RemoteCauseDeploymentPolicy/help-deployingOnlyWhenUpdates_fr.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/RemoteCauseDeploymentPolicy/help-deployingOnlyWhenUpdates_fr.html
@@ -1,0 +1,1 @@
+<div>Le deploiement n'est r&eacute;alis&eacute; que si les sources ont boug&eacute;.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/SCMTriggerCauseDeploymentPolicy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/SCMTriggerCauseDeploymentPolicy/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project" xmlns:util="jelly:util">
+
+	<f:entry title="" field="deployingOnlyWhenUpdates">
+		<f:checkbox name="deployingOnlyWhenUpdates" checked="${instance.deployingOnlyWhenUpdates}" title="${%SourceManagementDeploymentCriteria}" />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/SCMTriggerCauseDeploymentPolicy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/SCMTriggerCauseDeploymentPolicy/config.properties
@@ -1,0 +1,1 @@
+SourceManagementDeploymentCriteria=Deploy only when sources change

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/SCMTriggerCauseDeploymentPolicy/config_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/SCMTriggerCauseDeploymentPolicy/config_fr.properties
@@ -1,0 +1,1 @@
+SourceManagementDeploymentCriteria=Deploiement uniquement sur modifications des sources

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/SCMTriggerCauseDeploymentPolicy/help-deployingOnlyWhenUpdates.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/SCMTriggerCauseDeploymentPolicy/help-deployingOnlyWhenUpdates.html
@@ -1,0 +1,1 @@
+<div>The deployment task is executed if the project sources has been modified.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/SCMTriggerCauseDeploymentPolicy/help-deployingOnlyWhenUpdates_fr.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/SCMTriggerCauseDeploymentPolicy/help-deployingOnlyWhenUpdates_fr.html
@@ -1,0 +1,1 @@
+<div>Le deploiement n'est r&eacute;alis&eacute; que si les sources ont boug&eacute;.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/TimerTriggerCauseDeploymentPolicy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/TimerTriggerCauseDeploymentPolicy/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project" xmlns:util="jelly:util">
+
+	<f:entry title="" field="deployingOnlyWhenUpdates">
+		<f:checkbox name="deployingOnlyWhenUpdates" checked="${instance.deployingOnlyWhenUpdates}" title="${%SourceManagementDeploymentCriteria}" />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/TimerTriggerCauseDeploymentPolicy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/TimerTriggerCauseDeploymentPolicy/config.properties
@@ -1,0 +1,1 @@
+SourceManagementDeploymentCriteria=Deploy only when sources change

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/TimerTriggerCauseDeploymentPolicy/config_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/TimerTriggerCauseDeploymentPolicy/config_fr.properties
@@ -1,0 +1,1 @@
+SourceManagementDeploymentCriteria=Deploiement uniquement sur modifications des sources

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/TimerTriggerCauseDeploymentPolicy/help-deployingOnlyWhenUpdates.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/TimerTriggerCauseDeploymentPolicy/help-deployingOnlyWhenUpdates.html
@@ -1,0 +1,1 @@
+<div>The deployment task is executed if the project sources has been modified.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/TimerTriggerCauseDeploymentPolicy/help-deployingOnlyWhenUpdates_fr.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/TimerTriggerCauseDeploymentPolicy/help-deployingOnlyWhenUpdates_fr.html
@@ -1,0 +1,1 @@
+<div>Le deploiement n'est r&eacute;alis&eacute; que si les sources ont boug&eacute;.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UpstreamCauseDeploymentPolicy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UpstreamCauseDeploymentPolicy/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project" xmlns:util="jelly:util">
+
+	<f:entry title="" field="deployingOnlyWhenUpdates">
+		<f:checkbox name="deployingOnlyWhenUpdates" checked="${instance.deployingOnlyWhenUpdates}" title="${%SourceManagementDeploymentCriteria}" />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UpstreamCauseDeploymentPolicy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UpstreamCauseDeploymentPolicy/config.properties
@@ -1,0 +1,1 @@
+SourceManagementDeploymentCriteria=Deploy only when sources change

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UpstreamCauseDeploymentPolicy/config_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UpstreamCauseDeploymentPolicy/config_fr.properties
@@ -1,0 +1,1 @@
+SourceManagementDeploymentCriteria=Deploiement uniquement sur modifications des sources

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UpstreamCauseDeploymentPolicy/help-deployingOnlyWhenUpdates.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UpstreamCauseDeploymentPolicy/help-deployingOnlyWhenUpdates.html
@@ -1,0 +1,1 @@
+<div>The deployment task is executed if the project sources has been modified.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UpstreamCauseDeploymentPolicy/help-deployingOnlyWhenUpdates_fr.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UpstreamCauseDeploymentPolicy/help-deployingOnlyWhenUpdates_fr.html
@@ -1,0 +1,1 @@
+<div>Le deploiement n'est r&eacute;alis&eacute; que si les sources ont boug&eacute;.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UserIdCauseDeploymentPolicy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UserIdCauseDeploymentPolicy/config.jelly
@@ -1,0 +1,7 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project" xmlns:util="jelly:util">
+
+	<f:entry title="" field="deployingOnlyWhenUpdates">
+		<f:checkbox name="deployingOnlyWhenUpdates" checked="${instance.deployingOnlyWhenUpdates}" title="${%SourceManagementDeploymentCriteria}" />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UserIdCauseDeploymentPolicy/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UserIdCauseDeploymentPolicy/config.properties
@@ -1,0 +1,1 @@
+SourceManagementDeploymentCriteria=Deploy only when sources change

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UserIdCauseDeploymentPolicy/config_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UserIdCauseDeploymentPolicy/config_fr.properties
@@ -1,0 +1,1 @@
+SourceManagementDeploymentCriteria=Deploiement uniquement sur modifications des sources

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UserIdCauseDeploymentPolicy/help-deployingOnlyWhenUpdates.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UserIdCauseDeploymentPolicy/help-deployingOnlyWhenUpdates.html
@@ -1,0 +1,1 @@
+<div>The deployment task is executed if the project sources has been modified.</div>

--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UserIdCauseDeploymentPolicy/help-deployingOnlyWhenUpdates_fr.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/data/policy/UserIdCauseDeploymentPolicy/help-deployingOnlyWhenUpdates_fr.html
@@ -1,0 +1,1 @@
+<div>Le deploiement n'est r&eacute;alis&eacute; que si les sources ont boug&eacute;.</div>


### PR DESCRIPTION
It is now possible to specify "Deploy only when sources change" option for each individual deployment policy.

Implementation is backwards compatible. Old configurations continue to work without updating to new format. Only exception is that deprecated Causes are removed.

UX is similar to GitSCM plugin's extensions configuration.

## Before

![screen shot 2016-08-21 at 18 59 07](https://cloud.githubusercontent.com/assets/881222/17839035/0358cd6a-67e5-11e6-96a0-1bfd75d1b4ca.png)

## After

![screen shot 2016-08-21 at 21 02 23](https://cloud.githubusercontent.com/assets/881222/17839036/039b2fca-67e5-11e6-95bd-40c967e95758.png)