### PR TITLE
@DataBoundConstructor may not be used on an abstract class

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/AbstractDeploymentPolicy.java
+++ b/src/main/java/org/jenkinsci/plugins/deploy/weblogic/data/policy/AbstractDeploymentPolicy.java
@@ -15,7 +15,6 @@ public abstract class AbstractDeploymentPolicy extends AbstractDescribableImpl<A
 
     private boolean deployingOnlyWhenUpdates;
 
-    @DataBoundConstructor
     public AbstractDeploymentPolicy(boolean deployingOnlyWhenUpdates) {
         this.deployingOnlyWhenUpdates = deployingOnlyWhenUpdates;
     }


### PR DESCRIPTION
This check was introduced in a later version. 

https://github.com/stapler/stapler/commit/a219000a8ee5987b3a0017a17aab337330cf75de