### PR TITLE
Replace esclave with agent in weblogic-deployer plugin (fr)

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/help-baseResourcesGeneratedDirectory_fr.html
+++ b/src/main/resources/org/jenkinsci/plugins/deploy/weblogic/WeblogicDeploymentPlugin/help-baseResourcesGeneratedDirectory_fr.html
@@ -1,3 +1,3 @@
 <div>Chemin correspondant au repertoire parent dans lequel se trouve la ressource &agrave; deployer. Utile si la ressource  &agrave; deployer n'est pas g&eacute;n&eacute;r&eacute;e dans le repertoire workspace de Jenkins. Si absent le workspace sera utilis&eacute; comme base.<br/>
-Attention : Dans le cas d'un deploiement depuis un esclave, il est recommand&eacute; de r&eacute;aliser une copie de l'artifact &agrave; deployer dans le workspace et de laisser cette valeur vide.
+Attention : Dans le cas d'un deploiement depuis un agent, il est recommand&eacute; de r&eacute;aliser une copie de l'artifact &agrave; deployer dans le workspace et de laisser cette valeur vide.
 </div>


### PR DESCRIPTION
The word esclave appeared in the French documentation for the weblogic-deployer plugin; I changed it to agent (consistent with previous PRs).